### PR TITLE
#3 Modify SD009 to include non-English initiatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Modify SD009 to include non-English initiatives ([#3](https://github.com/Nictiz/api-requirements-docs/issues/3))
+
 ### Added
 
 - Add CHANGELOG.md

--- a/docs/api-specification-and-documentation.md
+++ b/docs/api-specification-and-documentation.md
@@ -167,22 +167,22 @@ when writing API client code.
   standards
     - Such as OpenAPI (formerly known as Swagger) and/or FHIR StructureDefinitions/OperationDefinitions.
 
-## SD009: API documentation MUST be published in English
+## SD009: API documentation SHOULD be published in English
 
 |                            |               |
 |----------------------------|---------------|
 | **Applicable roles**       | API specifier |
 | **Standardization levels** | OA, TSA, FSA  |
 | **Status**                 | Final         |
-| **Since version**          | 1.0.0         |
+| **Since version**          | 1.2.0         |
 
 ### Sub-requirements
 
-- **SD009.001**: API documentation **MUST** be available in English
-- **SD009.002**: Typical Dutch terminology and names of people and organizations **MUST** be written down in their
-  original Dutch form
-- **SD009.003**: Domain concepts **MUST** be translated to their corresponding official English terms instead of using
-  literal (word-for-word) translations
+- **SD009.001**: API documentation **SHOULD** be available in English
+- **SD009.002**: If API documentation is available in English, typical Dutch terminology and names of people and
+  organizations **MUST** be written down in their original Dutch form
+- **SD009.003**: If API documentation is available in English, domain concepts **MUST** be translated to their
+  corresponding official English terms instead of using literal (word-for-word) translations
 
 ## SD010: When documentation claims compliance to standards, specifications, guidelines and practices, policies or law, documentation MUST provide (references to) evidence to back up these claims
 


### PR DESCRIPTION
See issue #3 for background information.

## What?

Modify API requirement [SD009](https://nictiz.github.io/api-requirements-docs/v1.1.0/api-specification-and-documentation/#sd009-api-documentation-must-be-published-in-english) to include non-English initiatives.

## Why?

API specifications that include non-English documentation should not be excluded merely based on their language.

## How?

Make [SD009](https://nictiz.github.io/api-requirements-docs/v1.1.0/api-specification-and-documentation/#sd009-api-documentation-must-be-published-in-english) a SHOULD-have requirement, rather than a MUST-have requirement.